### PR TITLE
Fix: Display confirmation prompt in readConfirmation function

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -20,6 +20,7 @@ func readConfirmation(prompt string) bool {
 	}
 
 	// Normal interactive prompt
+	fmt.Print(prompt)
 	reader := bufio.NewReader(os.Stdin)
 	response, _ := reader.ReadString('\n')
 	response = strings.TrimSpace(strings.ToLower(response))


### PR DESCRIPTION
The readConfirmation function was not displaying the prompt in normal mode, causing commands like `caws remove` to appear to hang. The prompt was only shown in test mode but not in interactive mode.

This fix adds `fmt.Print(prompt)` before reading user input to ensure the confirmation question is visible to the user.

Fixes #1

----
Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/timdev/caws/actions/runs/18822329297) | [View branch](https://github.com/timdev/caws/tree/claude/issue-1-20251026-1857